### PR TITLE
Docker setup.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,0 @@
-FROM node:18.15.0-alpine3.16
-RUN apk add --no-cache git

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,17 +1,24 @@
 {
-  "name": "Node.js 18 Alpine",
-  "build": { "dockerfile": "Dockerfile" },
-  "postCreateCommand": "yarn install",
-  "postStartCommand": "yarn dev",
-"forwardPorts": [
-	3000
-],
+  "name": "Node 18.15.0 on Alpine 3.16",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "target": "node-base"
+  },
+  "forwardPorts": [ 3000 ],
+  "workspaceFolder": "/home/node/app",
+  "containerUser": "node",
+  "mounts": [
+    "source=${localWorkspaceFolder}/,target=/home/node/app/,type=bind,consistency=cached"
+  ],
   "customizations": {
     "vscode": {
       "extensions": [
+        "vue.volar",
         "bradlc.vscode-tailwindcss",
         "cpylua.language-postcss"
       ]
     }
-  }
-} 
+  },
+  "postCreateCommand": "yarn",
+  "postStartCommand": "yarn dev"
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.cache/
+.devcontainer/
+.nuxt/
+.vscode/
+node_modules/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "johnsoncodehk.volar",
-    "bradlc.vscode-tailwindcss"
+    "bradlc.vscode-tailwindcss",
+    "vue.volar"
   ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM node:18.15.0-alpine3.16 as node-base
+# docker build --no-cache --progress plain -t ricardobalk/nuxt3-tailwindcss:latest --target <target> -f Dockerfile .
+
+USER node
+ENV NPM_CONFIG_PREFIX=/home/node/.npm
+ENV PATH=$PATH:/home/node/.npm/bin
+
+RUN apk add --no-cache git
+
+RUN mkdir -p  "${HOME}/app" \
+              "${NPM_CONFIG_PREFIX}/bin"
+
+RUN printf  "Node version %s, npm version %s, yarn version %s\n\n" \
+            "$(node -v)" "$(npm -v)" "$(yarn -v)"
+
+FROM node-base as dependencies
+USER node
+WORKDIR /home/node/app
+COPY --chown=node:node . .
+RUN yarn
+ENTRYPOINT ["yarn", "run"]
+
+FROM dependencies as development
+USER node
+EXPOSE 3000
+CMD ["dev"]
+# && docker run -it -p 3000:3000 -v "$(pwd):/home/node/app:cached" ricardobalk/nuxt3-tailwindcss:latest
+
+FROM dependencies as build
+USER node
+RUN ["yarn", "run", "generate"]
+
+FROM nginx:1.21.1-alpine as production
+COPY --from=build /home/node/app/.output/public /usr/share/nginx/html
+EXPOSE 80 443
+CMD ["nginx", "-g", "daemon off;"]
+# && docker run -it -p 80:80 -p 443:443 -v "$(pwd)/nginx.conf:/etc/nginx/conf.d/default.conf:cached" ricardobalk/nuxt3-tailwindcss:latest

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,15 @@
+services:
+  nuxt3-tailwindcss:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=development
+    volumes:
+      - ./:/home/node/app/
+      - node_modules:/home/node/app/node_modules/
+volumes:
+  node_modules: {}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+services:
+  nuxt3-tailwindcss:
+    extends:
+        file: docker-compose.dev.yml
+        service: nuxt3-tailwindcss
+    build:
+      target: production
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      - NODE_ENV=production
+    volumes:
+      - ./:/home/node/app/
+      - node_modules:/home/node/app/node_modules/
+volumes:
+  node_modules: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,1 @@
+docker-compose.dev.yml


### PR DESCRIPTION
This PR adds a Docker setup to the Nuxt 3 starter kit.

If you're a developer using Docker, this makes it easier to get started with the starter kit, as you don't need to install Node.js, Yarn, Git, etc. locally on your machine. You can just use Docker to run it.

The Dockerfile has a multi-stage build, to keep the final image as small as possible.

In addition to the Docker setup, I've also added a `docker-compose.dev.yml` file and a `docker-compose.prod.yml`, which makes it easier to start the dev server and the production server.

I've also improved the current VSCode Dev Container set-up, so that VSCode is also using the same Dockerfile.